### PR TITLE
feat: Ignore error due to lack of certificate

### DIFF
--- a/src/infrastructure/http/http_axios.service.ts
+++ b/src/infrastructure/http/http_axios.service.ts
@@ -1,14 +1,20 @@
 import axios, { AxiosResponse } from 'axios';
 import { HttpService } from './http.abstract';
 import { InputHttpRequest } from './http.interfaces';
+import * as https from "https";
 
 export class HttpAxiosService implements HttpService {
   async request(input: InputHttpRequest): Promise<AxiosResponse<any, any>> {
+    const httpsAgent = new https.Agent({
+      rejectUnauthorized: false,
+    });
+
     return await axios({
       method: input.method,
       url: input.url,
       data: input.data,
       responseType: 'json',
+      httpsAgent: httpsAgent,
     });
   }
 }


### PR DESCRIPTION
Se achar que faz sentido para o projeto:

Passa a não rejeitar as requests dos callbacks em servidores locais que exigem certificado.